### PR TITLE
Introduced 'compile_python_ext' argument for codegen.

### DIFF
--- a/module/codegen/code_generator.py
+++ b/module/codegen/code_generator.py
@@ -12,7 +12,7 @@ import sys
 from . import utils
 
 
-def codegen(work, target_dir, python_ext_name, project_type, embedded,
+def codegen(work, target_dir, python_ext_name, project_type, compile_python_ext, embedded,
             force_rewrite, float_flag, long_flag):
     """
     Generate code
@@ -165,23 +165,22 @@ def codegen(work, target_dir, python_ext_name, project_type, embedded,
         os.chdir(current_dir)
         print("[done]")
 
-    # Compile python interface
-    sys.stdout.write("Compiling Python wrapper... \t\t\t\t\t")
-    sys.stdout.flush()
-    current_dir = os.getcwd()
-    os.chdir(target_src_dir)
-    call([sys.executable, 'setup.py', '--quiet', 'build_ext', '--inplace'])
-    print("[done]")
-
-    # Copy compiled solver
-    sys.stdout.write("Copying code-generated Python solver to current " +
-                     "directory... \t")
-    sys.stdout.flush()
-    module_name = glob('%s*' % python_ext_name + module_ext)
-    if not any(module_name):
-        raise ValueError('No Python module generated! ' +
-                         'Some errors have occurred.')
-    module_name = module_name[0]
-    sh.copy(module_name, current_dir)
-    os.chdir(current_dir)
-    print("[done]")
+    # Compile python interface and copy compiled solver
+    if compile_python_ext:
+        sys.stdout.write("Compiling Python wrapper... \t\t\t\t\t")
+        sys.stdout.flush()
+        current_dir = os.getcwd()
+        os.chdir(target_src_dir)
+        call([sys.executable, 'setup.py', '--quiet', 'build_ext', '--inplace'])
+        print("[done]")
+        sys.stdout.write("Copying code-generated Python solver to current " +
+                         "directory... \t")
+        sys.stdout.flush()
+        module_name = glob('%s*' % python_ext_name + module_ext)
+        if not any(module_name):
+            raise ValueError('No Python module generated! ' +
+                             'Some errors have occurred.')
+        module_name = module_name[0]
+        sh.copy(module_name, current_dir)
+        os.chdir(current_dir)
+        print("[done]")

--- a/module/interface.py
+++ b/module/interface.py
@@ -267,7 +267,7 @@ class OSQP(object):
             raise ValueError("Unrecognized fields")
 
     def codegen(self, folder, project_type='', parameters='vectors',
-                python_ext_name='emosqp', force_rewrite=False,
+                python_ext_name='emosqp', force_rewrite=False, compile_python_ext=True,
                 FLOAT=False, LONG=True):
         """
         Generate embeddable C code for the problem
@@ -310,7 +310,7 @@ class OSQP(object):
         print("[done]")
 
         # Generate code with codegen module
-        cg.codegen(work, folder, python_ext_name, project_type,
+        cg.codegen(work, folder, python_ext_name, project_type, compile_python_ext,
                    embedded, force_rewrite, float_flag, long_flag)
 
     def derivative_iterative_refinement(self, rhs, max_iter=20, tol=1e-12):


### PR DESCRIPTION
Users might want to generate code without compiling the python extension. One such case is when `OSQP` codegen is used within `CVXPY` codegen, and the `CVXPY` python extension is used for prototyping. 

This PR introduces the argument 'compile_python_ext'. If `True` (default), the python extension is compiled. If `False`, all files related to the python extension are still rendered and the `CMake` project is still created. This way, advanced users can still compile the python extension by hand, for example by:

```bash
cd dir_name/src
python setup.py --quiet build_ext --inplace
```