### PR TITLE
building wheels on cp3*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 write_to = "src/osqp/_version.py"
 
 [tool.cibuildwheel]
-build = "cp3?-*"
+build = "cp3*"
 skip = "*-win32 *-manylinux_i686 *-musllinux_*"
 test-requires = ["pytest"]
 test-command = "pytest -s {project}/src/osqp/tests -k \"not codegen and not mkl\""


### PR DESCRIPTION
Set the `cibuildwheel` python version to `cp-3*` to allow building wheels on Python `3.10` and beyond.