### PR TITLE
vb/ghactions fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,13 +33,15 @@ jobs:
 
     - name: Build wheels
       run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade build
         python -m pip install cibuildwheel
         python -m cibuildwheel --output-dir wheelhouse
 
     - name: Build source
       if: startsWith(matrix.os, 'ubuntu')
       run: |
-        python setup.py sdist --dist-dir=wheelhouse
+        python -m build . --sdist --outdir wheelhouse
 
     - name: Release to pypi
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')

--- a/src/osqp/codegen/files_to_generate/setup.py
+++ b/src/osqp/codegen/files_to_generate/setup.py
@@ -74,7 +74,7 @@ PYTHON_EXT_NAME = Extension('PYTHON_EXT_NAME',
 
 
 setup(name='PYTHON_EXT_NAME',
-      version='0.6.2.post4',
+      version='0.6.2.post5',
       author='Bartolomeo Stellato, Goran Banjac',
       author_email='bartolomeo.stellato@gmail.com',
       description='This is the Python module for embedded OSQP: ' +

--- a/src/osqp/codegen/files_to_generate/setup.py
+++ b/src/osqp/codegen/files_to_generate/setup.py
@@ -74,7 +74,7 @@ PYTHON_EXT_NAME = Extension('PYTHON_EXT_NAME',
 
 
 setup(name='PYTHON_EXT_NAME',
-      version='0.6.2.post3',
+      version='0.6.2.post4',
       author='Bartolomeo Stellato, Goran Banjac',
       author_email='bartolomeo.stellato@gmail.com',
       description='This is the Python module for embedded OSQP: ' +

--- a/src/osqp/interface.py
+++ b/src/osqp/interface.py
@@ -1,5 +1,5 @@
 """
-Python interface module for OSQP solver v0.6.2.post3
+Python interface module for OSQP solver v0.6.2.post4
 """
 from __future__ import print_function
 from builtins import object

--- a/src/osqp/interface.py
+++ b/src/osqp/interface.py
@@ -1,5 +1,5 @@
 """
-Python interface module for OSQP solver v0.6.2.post4
+Python interface module for OSQP solver v0.6.2.post5
 """
 from __future__ import print_function
 from builtins import object

--- a/src/osqppurepy/_osqp.py
+++ b/src/osqppurepy/_osqp.py
@@ -330,7 +330,7 @@ class OSQP(object):
     work    - workspace
     """
     def __init__(self):
-        self._version = "0.6.2.post3"
+        self._version = "0.6.2.post4"
 
     @property
     def version(self):

--- a/src/osqppurepy/_osqp.py
+++ b/src/osqppurepy/_osqp.py
@@ -330,7 +330,7 @@ class OSQP(object):
     work    - workspace
     """
     def __init__(self):
-        self._version = "0.6.2.post4"
+        self._version = "0.6.2.post5"
 
     @property
     def version(self):


### PR DESCRIPTION
A few minor changes to the workflow (`python setup.py sdist` will not dynamically pick up the project from the tag, but `python -m build . --sdist` will). There are still a few places where a (manual) bumpversion is needed (in addition to the tag):

  - src/osqp/interface.py
  - src/osqp/codegen/files_to_generate/setup.py 
  - src/osqppurepy/_osqp.py

I will fix these instances soon so that a tag is all that's needed in the future.