### PR TITLE
use oldest supported numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["numpy>=1.7", "setuptools>=40.8.0", "wheel", "setuptools_scm>=6.2", "qdldl"]
+requires = ["oldest-supported-numpy", "setuptools>=40.8.0", "wheel", "setuptools_scm>=6.2", "qdldl"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
It is best practice to build against the oldest version of Numpy a package can work with, as binaries compiled with old Numpy versions are binary compatible with newer Numpy versions, but not vice versa.

With ecos2.0.8 I'm experiencing the same as for example displayed in cvxpy/cvxpy#1367.
See https://pypi.org/project/oldest-supported-numpy/ for more details

Same PR as for ecos: https://github.com/embotech/ecos-python/pull/37