### PR TITLE
fix: replace np.int alias with builtin int

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,6 @@ build = "cp3*"
 skip = "*-win32 *-manylinux_i686 *-musllinux_*"
 test-requires = ["pytest"]
 test-command = "pytest -s {project}/src/osqp/tests -k \"not codegen and not mkl\""
+
+[tool.black]
+exclude = "*"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy >= 1.7
+numpy >= 1.20
 scipy >= 0.13.2
 qdldl

--- a/src/osqp/utils.py
+++ b/src/osqp/utils.py
@@ -71,16 +71,16 @@ def prepare_data(P=None, q=None, A=None, l=None, u=None, **settings):
         # Create elements if they are not specified
         if P is None:
             P = sparse.csc_matrix((np.zeros((0,), dtype=np.double),
-                                   np.zeros((0,), dtype=np.int),
-                                   np.zeros((n+1,), dtype=np.int)),
+                                   np.zeros((0,), dtype=int),
+                                   np.zeros((n+1,), dtype=int)),
                                   shape=(n, n))
         if q is None:
             q = np.zeros(n)
 
         if A is None:
             A = sparse.csc_matrix((np.zeros((0,), dtype=np.double),
-                                   np.zeros((0,), dtype=np.int),
-                                   np.zeros((n+1,), dtype=np.int)),
+                                   np.zeros((0,), dtype=int),
+                                   np.zeros((n+1,), dtype=int)),
                                   shape=(m, n))
             l = np.zeros(A.shape[0])
             u = np.zeros(A.shape[0])

--- a/src/osqppurepy/interface.py
+++ b/src/osqppurepy/interface.py
@@ -61,16 +61,16 @@ class OSQP(object):
         # Create elements if they are not specified
         if P is None:
             P = sparse.csc_matrix((np.zeros((0,), dtype=np.double),
-                                  np.zeros((0,), dtype=np.int),
-                                  np.zeros((n+1,), dtype=np.int)),
+                                  np.zeros((0,), dtype=int),
+                                  np.zeros((n+1,), dtype=int)),
                                   shape=(n, n))
         if q is None:
             q = np.zeros(n)
 
         if A is None:
             A = sparse.csc_matrix((np.zeros((0,), dtype=np.double),
-                                  np.zeros((0,), dtype=np.int),
-                                  np.zeros((n+1,), dtype=np.int)),
+                                  np.zeros((0,), dtype=int),
+                                  np.zeros((n+1,), dtype=int)),
                                   shape=(m, n))
             l = np.zeros(A.shape[0])
             u = np.zeros(A.shape[0])


### PR DESCRIPTION
This changes the `np.int` alias of the Python builtin `int` type as the alias was deprecated in numpy version [1.20.0](https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated) and lead to an `AttributeError` starting with version [1.24.0](https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations).

This should fix issue #104 