### PR TITLE
Trying default algebra on py 3.11 and 3.12

### DIFF
--- a/.github/workflows/build_cuda.yml
+++ b/.github/workflows/build_cuda.yml
@@ -44,7 +44,7 @@ jobs:
       env:
         CIBW_BUILD: cp38-* cp39-* cp310-*
         CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_* *-macosx_*"
-        CIBW_TEST_REQUIRES: pytest torch numdifftools
+        CIBW_BEFORE_TEST: pip3 install pytest numdifftools && pip3 install torch --index-url https://download.pytorch.org/whl/nightly/cpu
 
         CIBW_ENVIRONMENT_LINUX: OSQP_ALGEBRA_BACKEND=cuda CMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc
         CIBW_BEFORE_ALL_LINUX: bash .github/workflows/prepare_build_environment_linux_cuda.sh

--- a/.github/workflows/build_default.yml
+++ b/.github/workflows/build_default.yml
@@ -44,7 +44,7 @@ jobs:
       env:
         CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
         CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
-        CIBW_TEST_REQUIRES: pytest torch numdifftools
+        CIBW_BEFORE_TEST: pip3 install pytest numdifftools && pip3 install torch --index-url https://download.pytorch.org/whl/nightly/cpu
         CIBW_TEST_COMMAND: "python -m pytest -s {project}/src/osqp/tests"
 
     - name: Build source

--- a/.github/workflows/build_default.yml
+++ b/.github/workflows/build_default.yml
@@ -44,6 +44,7 @@ jobs:
       env:
         CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
         CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
+        CIBW_BEFORE_BUILD: cd {project} && git clean -fdx
         CIBW_BEFORE_TEST: pip3 install pytest numdifftools && pip3 install torch --index-url https://download.pytorch.org/whl/nightly/cpu
         CIBW_TEST_COMMAND: "python -m pytest -s {project}/src/osqp/tests"
 

--- a/.github/workflows/build_default.yml
+++ b/.github/workflows/build_default.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-2022]
+        os: [ubuntu-latest, macos-latest, windows-2022]
 
     steps:
     - uses: actions/checkout@master
@@ -42,7 +42,7 @@ jobs:
       with:
         output-dir: wheelhouse
       env:
-        CIBW_BUILD: cp39-* cp310-* cp311-* cp312-*
+        CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
         CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
         CIBW_BEFORE_TEST: pip3 install pytest numdifftools && pip3 install torch --index-url https://download.pytorch.org/whl/nightly/cpu
         CIBW_TEST_COMMAND: "python -m pytest -s {project}/src/osqp/tests"

--- a/.github/workflows/build_default.yml
+++ b/.github/workflows/build_default.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         output-dir: wheelhouse
       env:
-        CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
+        CIBW_BUILD: cp39-* cp310-* cp311-* cp312-*
         CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
         CIBW_BEFORE_TEST: pip3 install pytest numdifftools && pip3 install torch --index-url https://download.pytorch.org/whl/nightly/cpu
         CIBW_TEST_COMMAND: "python -m pytest -s {project}/src/osqp/tests"

--- a/.github/workflows/build_default.yml
+++ b/.github/workflows/build_default.yml
@@ -44,7 +44,7 @@ jobs:
       env:
         CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
         CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
-        CIBW_BEFORE_BUILD: cd {project} && git clean -fdx
+        _CIBW_BEFORE_BUILD: cd {project} && git clean -fdx
         CIBW_BEFORE_TEST: pip3 install pytest numdifftools && pip3 install torch --index-url https://download.pytorch.org/whl/nightly/cpu
         CIBW_TEST_COMMAND: "python -m pytest -s {project}/src/osqp/tests"
 

--- a/.github/workflows/build_default.yml
+++ b/.github/workflows/build_default.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         output-dir: wheelhouse
       env:
-        CIBW_BUILD: cp38-* cp39-* cp310-*
+        CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
         CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
         CIBW_TEST_REQUIRES: pytest torch numdifftools
         CIBW_TEST_COMMAND: "python -m pytest -s {project}/src/osqp/tests"

--- a/.github/workflows/build_default.yml
+++ b/.github/workflows/build_default.yml
@@ -38,7 +38,7 @@ jobs:
         python-version: '3.9'
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.3.1
+      uses: pypa/cibuildwheel@v2.16.2
       with:
         output-dir: wheelhouse
       env:

--- a/.github/workflows/build_mkl.yml
+++ b/.github/workflows/build_mkl.yml
@@ -45,7 +45,7 @@ jobs:
       env:
         CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
         CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
-        CIBW_TEST_REQUIRES: pytest torch numdifftools mkl mkl-devel
+        CIBW_BEFORE_TEST: pip3 install pytest numdifftools mkl mkl-devel && pip3 install torch --index-url https://download.pytorch.org/whl/nightly/cpu
 
         CIBW_BEFORE_ALL_LINUX: bash .github/workflows/prepare_build_environment_linux_mkl.sh
         CIBW_ENVIRONMENT_LINUX: "OSQP_ALGEBRA_BACKEND=mkl MKL_ROOT=/opt/intel/oneapi/mkl/latest"

--- a/.github/workflows/build_mkl.yml
+++ b/.github/workflows/build_mkl.yml
@@ -38,12 +38,12 @@ jobs:
         python-version: '3.9'
 
     - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==2.12.3
+      run: python -m pip install cibuildwheel==2.16.2
 
     - name: Build wheels
       run: python -m cibuildwheel --output-dir wheelhouse
       env:
-        CIBW_BUILD: cp38-* cp39-* cp310-*
+        CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
         CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
         CIBW_TEST_REQUIRES: pytest torch numdifftools mkl mkl-devel
 

--- a/.github/workflows/prepare_build_environment_linux_mkl.sh
+++ b/.github/workflows/prepare_build_environment_linux_mkl.sh
@@ -7,4 +7,4 @@ pip install "cmake==3.22.*"
 
 yum-config-manager --add-repo https://yum.repos.intel.com/oneapi
 rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-yum install -y intel-oneapi-mkl-devel-2023.0.0
+yum install -y intel-oneapi-mkl-devel-2023.0.0 --nogpgcheck

--- a/setup.py
+++ b/setup.py
@@ -166,7 +166,7 @@ setup(
     package_data={'osqp.codegen.pywrapper': ['*.jinja']},
     include_package_data=True,
     zip_safe=False,
-    install_requires=['numpy>=1.7', 'scipy>=0.13.2', 'qdldl', 'jinja2'],
+    install_requires=['numpy>=1.7', 'scipy>=0.13.2', 'qdldl', 'jinja2', 'setuptools'],
     python_requires='>=3.7',
     extras_require=extras_require,
     license='Apache 2.0',


### PR DESCRIPTION
A couple of notes:
`torch` for python 3.12 is available not from PyPI but using:
```
pip3 install torch --index-url https://download.pytorch.org/whl/nightly/cpu
```