### PR TITLE
Add macOS arm64 wheel builds for v0.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2022]
+        # Include macos-13 to get Intel x86_64 macs and maos-latest to get the Aaarch64 macs
+        os: [ubuntu-latest, macos-latest, macos-13, windows-2022]
+
+        # Build on the native architectures (macos-latest is arm64. macos-13 is x86_64)
+        include:
+        - os: macos-latest
+          osx_arch: 'arm64'
+        - os: macos-13
+          osx_arch: 'x86_64'
 
     steps:
     - uses: actions/checkout@master
@@ -38,9 +46,13 @@ jobs:
         python -m pip install cibuildwheel
         python -m cibuildwheel --output-dir wheelhouse
       env:
+        CIBW_BUILD: "cp3*"
+        # Skip testing on arm64 Python 3.8 because it uses the x86_64 executable, not the arm executable
+        CIBW_TEST_SKIP: "cp38-macosx_*:arm64"
         CIBW_ENVIRONMENT_LINUX: CMAKE_GENERATOR="Unix Makefiles"
-        CIBW_ENVIRONMENT_MACOS: CMAKE_GENERATOR="Unix Makefiles"
+        CIBW_ENVIRONMENT_MACOS: CMAKE_GENERATOR="Unix Makefiles" CMAKE_OSX_ARCHITECTURES=${{ matrix.osx_arch }}
         CIBW_ENVIRONMENT_WINDOWS: CMAKE_GENERATOR="Visual Studio 17 2022" CMAKE_GENERATOR_PLATFORM=x64
+        CIBW_BUILD_VERBOSITY: 1
 
     - name: Build source
       if: startsWith(matrix.os, 'ubuntu')

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if OSQP_ARG_MARK in sys.argv:
 
 cmake_args = []
 # What variables from the environment do we wish to pass on to cmake as variables?
-cmake_env_vars = ('CMAKE_GENERATOR', 'CMAKE_GENERATOR_PLATFORM')
+cmake_env_vars = ('CMAKE_GENERATOR', 'CMAKE_GENERATOR_PLATFORM', 'CMAKE_OSX_ARCHITECTURES')
 for cmake_env_var in cmake_env_vars:
     cmake_var = os.environ.get(cmake_env_var)
     if cmake_var:


### PR DESCRIPTION
Add the macOS arm64 architecture to the wheel builds of the 0.6 branch. This is done similar to qdldl-python in https://github.com/osqp/qdldl-python/pull/39.