### PR TITLE
Only exclude SciPy version 1.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,10 @@ dependencies = [
     "jinja2",
     "numpy>=1.7",
     "qdldl",
-    "scipy>=0.13.2,<1.12.0",
+    # Exclude scipy 1.12 because the random sparse array function started returning
+    # the transpose of the original, breaking the unit tests. This was fixed in 1.13.0.
+    # ref: https://github.com/scipy/scipy/issues/20027
+    "scipy>=0.13.2,!=1.12.0",
     "setuptools",
     "joblib",
 ]


### PR DESCRIPTION
SciPy 1.13 fixed the sparse matrix ordering problem we had with the tests, so we can now use that.