### PR TITLE
Update CI wheel building

### DIFF
--- a/.github/workflows/build_aarch64.yml
+++ b/.github/workflows/build_aarch64.yml
@@ -2,11 +2,13 @@ name: Build aarch64
 
 on:
   push:
-    branches: [ master, develop* ]
+    branches:
+      - master
     tags:
       - '*'
   pull_request:
-    branches: [ master, develop* ]
+    branches:
+      - master
 
 jobs:
   build_wheels:

--- a/.github/workflows/build_aarch64.yml
+++ b/.github/workflows/build_aarch64.yml
@@ -37,6 +37,7 @@ jobs:
         CIBW_TEST_REQUIRES: "pytest torch numdifftools"
         CIBW_TEST_COMMAND: "python -m pytest -s {project}/src/osqp/tests"
         CIBW_ENVIRONMENT_LINUX: CMAKE_GENERATOR="Unix Makefiles"
+        CIBW_BUILD_VERBOSITY: 1
 
     - name: Release to pypi
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')

--- a/.github/workflows/build_aarch64.yml
+++ b/.github/workflows/build_aarch64.yml
@@ -30,7 +30,7 @@ jobs:
       with:
         output-dir: wheelhouse
       env:
-        CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
+        CIBW_BUILD: "cp3?-*"
         CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
         CIBW_ARCHS_LINUX: aarch64
         CIBW_BEFORE_ALL: "yum -y update && yum install -y blas-devel lapack-devel"

--- a/.github/workflows/build_aarch64.yml
+++ b/.github/workflows/build_aarch64.yml
@@ -49,7 +49,20 @@ jobs:
         twine upload wheelhouse/*
 
     - name: Upload artifacts to github
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-${{ matrix.os }}
         path: ./wheelhouse
+
+
+  merge_wheels:
+    name: Merge wheel artifacts from build_wheels OS matrix jobs
+    runs-on: ubuntu-latest
+    needs: build_wheels
+    steps:
+      - name: Merge artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: wheels
+          pattern: wheels-*
+          delete-merged: true

--- a/.github/workflows/build_cuda.yml
+++ b/.github/workflows/build_cuda.yml
@@ -36,7 +36,7 @@ jobs:
         package-dir: backend/cuda
         output-dir: wheelhouse
       env:
-        CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
+        CIBW_BUILD: "cp3?-*"
         CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_* *-macosx_*"
         CIBW_TEST_REQUIRES: setuptools pytest torch numdifftools
         CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/build_cuda.yml
+++ b/.github/workflows/build_cuda.yml
@@ -39,6 +39,7 @@ jobs:
         CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
         CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_* *-macosx_*"
         CIBW_TEST_REQUIRES: setuptools pytest torch numdifftools
+        CIBW_BUILD_VERBOSITY: 1
 
         CIBW_ENVIRONMENT_LINUX: CMAKE_CUDA_COMPILER=/usr/local/cuda-11.7/bin/nvcc
         CIBW_BEFORE_ALL_LINUX: bash .github/workflows/prepare_build_environment_linux_cuda.sh

--- a/.github/workflows/build_cuda.yml
+++ b/.github/workflows/build_cuda.yml
@@ -2,11 +2,13 @@ name: Build CUDA
 
 on:
   push:
-    branches: [ master, develop* ]
+    branches:
+      - master
     tags:
       - '*'
   pull_request:
-    branches: [ master, develop* ]
+    branches:
+      - master
 
 jobs:
   build_wheels:

--- a/.github/workflows/build_cuda.yml
+++ b/.github/workflows/build_cuda.yml
@@ -50,7 +50,20 @@ jobs:
         CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: ""
 
     - name: Upload artifacts to github
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-${{ matrix.os }}
         path: ./wheelhouse
+
+
+  merge_wheels:
+    name: Merge wheel artifacts from build_wheels OS matrix jobs
+    runs-on: ubuntu-latest
+    needs: build_wheels
+    steps:
+      - name: Merge artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: wheels
+          pattern: wheels-*
+          delete-merged: true

--- a/.github/workflows/build_default.yml
+++ b/.github/workflows/build_default.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         output-dir: wheelhouse
       env:
-        CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
+        CIBW_BUILD: "cp3?-*"
         CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
         CIBW_TEST_REQUIRES: setuptools pytest torch numdifftools
         CIBW_TEST_COMMAND: "python -m pytest -s {project}/src/osqp/tests -k \"not codegen\""

--- a/.github/workflows/build_default.yml
+++ b/.github/workflows/build_default.yml
@@ -15,7 +15,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2022]
+        # Include macos-13 to get Intel x86_64 macs and maos-latest to get the Aaarch64 macs
+        os: [ubuntu-latest, macos-latest, macos-13, windows-2022]
+
+        # Build on the native architectures (macos-latest is arm64. macos-13 is x86_64)
+        include:
+        - os: macos-latest
+          osx_arch: 'arm64'
+        - os: macos-13
+          osx_arch: 'x86_64'
 
     steps:
     - uses: actions/checkout@master
@@ -29,6 +37,7 @@ jobs:
         CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
         CIBW_TEST_REQUIRES: setuptools pytest torch numdifftools
         CIBW_TEST_COMMAND: "python -m pytest -s {project}/src/osqp/tests -k \"not codegen\""
+        CIBW_ENVIRONMENT_MACOS: CMAKE_OSX_ARCHITECTURES=${{ matrix.osx_arch }}
 
     - name: Build source
       if: runner.os == 'Linux'

--- a/.github/workflows/build_default.yml
+++ b/.github/workflows/build_default.yml
@@ -38,6 +38,7 @@ jobs:
         CIBW_TEST_REQUIRES: setuptools pytest torch numdifftools
         CIBW_TEST_COMMAND: "python -m pytest -s {project}/src/osqp/tests -k \"not codegen\""
         CIBW_ENVIRONMENT_MACOS: CMAKE_OSX_ARCHITECTURES=${{ matrix.osx_arch }}
+        CIBW_BUILD_VERBOSITY: 1
 
     - name: Build source
       if: runner.os == 'Linux'

--- a/.github/workflows/build_default.yml
+++ b/.github/workflows/build_default.yml
@@ -2,11 +2,13 @@ name: Build Default
 
 on:
   push:
-    branches: [ master, develop* ]
+    branches:
+      - master
     tags:
       - '*'
   pull_request:
-    branches: [ master, develop* ]
+    branches:
+      - master
 
 jobs:
   build_wheels:

--- a/.github/workflows/build_default.yml
+++ b/.github/workflows/build_default.yml
@@ -57,7 +57,20 @@ jobs:
         twine upload wheelhouse/*
 
     - name: Upload artifacts to github
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-${{ matrix.os }}
         path: ./wheelhouse
+
+
+  merge_wheels:
+    name: Merge wheel artifacts from build_wheels OS matrix jobs
+    runs-on: ubuntu-latest
+    needs: build_wheels
+    steps:
+      - name: Merge artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: wheels
+          pattern: wheels-*
+          delete-merged: true

--- a/.github/workflows/build_mkl.yml
+++ b/.github/workflows/build_mkl.yml
@@ -28,7 +28,7 @@ jobs:
         package-dir: backend/mkl
         output-dir: wheelhouse
       env:
-        CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
+        CIBW_BUILD: "cp3?-*"
         CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
         CIBW_TEST_REQUIRES: setuptools pytest torch numdifftools mkl mkl-devel
         CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/build_mkl.yml
+++ b/.github/workflows/build_mkl.yml
@@ -2,11 +2,13 @@ name: Build MKL
 
 on:
   push:
-    branches: [ master, develop* ]
+    branches:
+      - master
     tags:
       - '*'
   pull_request:
-    branches: [ master, develop* ]
+    branches:
+      - master
 
 jobs:
   build_wheels:

--- a/.github/workflows/build_mkl.yml
+++ b/.github/workflows/build_mkl.yml
@@ -46,7 +46,20 @@ jobs:
         CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair {wheel} --wheel-dir {dest_dir} --no-mangle-all --add-path \"C:/Program Files (x86)/Intel/oneAPI/mkl/latest/redist/intel64\" --add-dll \"mkl_sequential.2.dll;mkl_def.2.dll;mkl_intel_thread.2.dll\""
 
     - name: Upload artifacts to github
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-${{ matrix.os }}
         path: ./wheelhouse
+
+
+  merge_wheels:
+    name: Merge wheel artifacts from build_wheels OS matrix jobs
+    runs-on: ubuntu-latest
+    needs: build_wheels
+    steps:
+      - name: Merge artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: wheels
+          pattern: wheels-*
+          delete-merged: true

--- a/.github/workflows/build_mkl.yml
+++ b/.github/workflows/build_mkl.yml
@@ -31,6 +31,7 @@ jobs:
         CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
         CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
         CIBW_TEST_REQUIRES: setuptools pytest torch numdifftools mkl mkl-devel
+        CIBW_BUILD_VERBOSITY: 1
 
         CIBW_BEFORE_ALL_LINUX: bash .github/workflows/prepare_build_environment_linux_mkl.sh
         CIBW_ENVIRONMENT_LINUX: "MKL_ROOT=/opt/intel/oneapi/mkl/latest"

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -2,9 +2,13 @@ name: Pre-commit checks
 
 on:
   push:
-    branches: [ master, develop* ]
+    # Run this workflow on all branches because it is good to flag these errors
+    # and this workflow is "cheap"
+    branches:
+      - '*'
   pull_request:
-    branches: [ master, develop* ]
+    branches:
+      - master
 
 jobs:
   precommit:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ set(OSQP_CUSTOM_PRINTING "${CMAKE_CURRENT_SOURCE_DIR}/cmake/printing.h")
 set(OSQP_CUSTOM_MEMORY "${CMAKE_CURRENT_SOURCE_DIR}/cmake/memory.h")
 set(OSQP_CODEGEN_INSTALL_DIR "codegen/codegen_src" CACHE PATH "" FORCE)
 
+if(APPLE)
+    message(STATUS "Building for Apple arches: ${CMAKE_OSX_ARCHITECTURES}")
+endif()
+
 include(FetchContent)
 
 find_package(pybind11 CONFIG REQUIRED)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ sdist.include = ["src/osqp/_version.py"]
 [tool.scikit-build.cmake.define]
 OSQP_ALGEBRA_BACKEND = "builtin"
 OSQP_EXT_MODULE_NAME = "ext_builtin"
+CMAKE_OSX_ARCHITECTURES = {env="CMAKE_OSX_ARCHITECTURES"}
 
 [tool.pytest.ini_options]
 testpaths = ["src/osqp/tests"]


### PR DESCRIPTION
Various updates to the CI system, including:

* Build both the arm64 and x86_64 macOS wheels on GitHub actions. The macos-13 runner is x86_64 architecture, so build those wheels there. The macos-latest runner is arm64 architecture, so build those wheels there.
* Change the version string to build for all support Python versions by default.
* Update to artifacts v4 action. This requires uploading each OS' artifacts separately and then combining them in another job after the matrix is completed.

Update the workflow triggering conditions:
* No longer use a develop branch, so only run with PRs against the
  master branch
* Run the pre-commit checks on all branches to flag potential errors
  before a PR is made