### PR TITLE
[CI] Updates pyproject.toml for NumPy 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,10 @@
 [build-system]
-requires = ["scikit-build-core", "pybind11"]
+requires = [
+    "numpy >= 2.0.0; python_version > '3.8'",
+    "oldest-supported-numpy; python_version <= '3.8'",
+    "scikit-build-core", 
+    "pybind11"
+]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
The recent NumPy 2.0 release broke our installation using wheels. This change ensures that NumPy 2.0 is used to compile, which is backward compatible.

The same update has been merged/proposed for CVXPY, ECOS, and SCS. 
