### PR TITLE
no dl/du in osqp_adjoint_derivative_compute anymore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ list(APPEND CMAKE_MESSAGE_INDENT "  ")
 FetchContent_Declare(
   osqp
   GIT_REPOSITORY https://github.com/osqp/osqp.git
-  GIT_TAG 02a117cfc8ad21b06c2596603a2046ee61c82786
+  GIT_TAG ff371613bef82e85fb431590343853846ff96203
 )
 list(POP_BACK CMAKE_MESSAGE_INDENT)
 FetchContent_MakeAvailable(osqp)

--- a/src/bindings.cpp.in
+++ b/src/bindings.cpp.in
@@ -118,7 +118,7 @@ class PyOSQPSolver {
         OSQPInt update_data_mat(py::object, py::object, py::object, py::object);
         OSQPInt warm_start(py::object, py::object);
         OSQPInt solve();
-        OSQPInt adjoint_derivative_compute(py::object, py::object, py::object);
+        OSQPInt adjoint_derivative_compute(py::object, py::object);
         OSQPInt adjoint_derivative_get_mat(CSC&, CSC&);
         OSQPInt adjoint_derivative_get_vec(py::object, py::object, py::object);
 
@@ -273,10 +273,9 @@ OSQPInt PyOSQPSolver::update_data_mat(py::object P_x, py::object P_i, py::object
     return osqp_update_data_mat(this->_solver, _P_x, _P_i, _P_n, _A_x, _A_i, _A_n);
 }
 
-OSQPInt PyOSQPSolver::adjoint_derivative_compute(const py::object dx, const py::object dy_l, const py::object dy_u) {
+OSQPInt PyOSQPSolver::adjoint_derivative_compute(const py::object dx, const py::object dy) {
     OSQPFloat* _dx;
-    OSQPFloat* _dy_l;
-    OSQPFloat* _dy_u;
+    OSQPFloat* _dy;
 
     if (dx.is_none()) {
         _dx = NULL;
@@ -285,21 +284,15 @@ OSQPInt PyOSQPSolver::adjoint_derivative_compute(const py::object dx, const py::
         _dx = (OSQPFloat *)_dx_array.data();
     }
 
-    if (dy_l.is_none()) {
-        _dy_l = NULL;
+    if (dy.is_none()) {
+        _dy = NULL;
     } else {
-        auto _dy_l_array = py::array_t<OSQPFloat>(dy_l);
-        _dy_l = (OSQPFloat *)_dy_l_array.data();
+        auto _dy_array = py::array_t<OSQPFloat>(dy);
+        _dy = (OSQPFloat *)_dy_array.data();
     }
 
-    if (dy_u.is_none()) {
-        _dy_u = NULL;
-    } else {
-        auto _dy_u_array = py::array_t<OSQPFloat>(dy_u);
-        _dy_u = (OSQPFloat *)_dy_u_array.data();
-    }
 
-    return osqp_adjoint_derivative_compute(this->_solver, _dx, _dy_l, _dy_u);
+    return osqp_adjoint_derivative_compute(this->_solver, _dx, _dy);
 
 }
 
@@ -486,7 +479,7 @@ PYBIND11_MODULE(@OSQP_EXT_MODULE_NAME@, m) {
     .def("update_rho", &PyOSQPSolver::update_rho)
     .def("get_settings", &PyOSQPSolver::get_settings, py::return_value_policy::reference)
 
-    .def("adjoint_derivative_compute", &PyOSQPSolver::adjoint_derivative_compute, "dx"_a.none(true), "dy_l"_a.none(true), "dy_u"_a.none(true))
+    .def("adjoint_derivative_compute", &PyOSQPSolver::adjoint_derivative_compute, "dx"_a.none(true), "dy"_a.none(true))
     .def("adjoint_derivative_get_mat", &PyOSQPSolver::adjoint_derivative_get_mat, "dP"_a, "dA"_a)
     .def("adjoint_derivative_get_vec", &PyOSQPSolver::adjoint_derivative_get_vec, "dq"_a, "dl"_a, "du"_a)
 

--- a/src/osqp/interface.py
+++ b/src/osqp/interface.py
@@ -433,7 +433,7 @@ class OSQP:
 
         return folder
 
-    def adjoint_derivative_compute(self, dx=None, dy_l=None, dy_u=None):
+    def adjoint_derivative_compute(self, dx=None, dy=None):
         """
         Compute adjoint derivative after solve.
         """
@@ -450,12 +450,10 @@ class OSQP:
         if results.info.status != 'solved':
             raise ValueError('Problem has not been solved to optimality. ' 'You cannot take derivatives')
 
-        if dy_u is None:
-            dy_u = np.zeros(self.m)
-        if dy_l is None:
-            dy_l = np.zeros(self.m)
+        if dy is None:
+            dy = np.zeros(self.m)
 
-        self._solver.adjoint_derivative_compute(dx, dy_l, dy_u)
+        self._solver.adjoint_derivative_compute(dx, dy)
 
     def adjoint_derivative_get_mat(self, as_dense=True, dP_as_triu=True):
         """


### PR DESCRIPTION
python wrapper api change to account for the fact that `osqp_adjoint_derivative_compute` doesn't support a `y_l` and `y_u` anymore.

Pinning to current HEAD of `osqp` `master`.