### PR TITLE
removed support for py<3.8,

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "osqp"
 dynamic = ["version"]
 description = "OSQP: The Operator Splitting QP Solver"
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "Bartolomeo Stellato", email = "bartolomeo.stellato@gmail.com" },
     { name = "Goran Banjac" },


### PR DESCRIPTION
 `osqp` requires python>=3.8, since codegen doesn't support it (on account of pybind11 not supporting it), and we're only testing on cibuildwheel with py>=3.8