### PR TITLE
failing as we should, instead of printing out an error

### DIFF
--- a/src/osqp/nn/torch.py
+++ b/src/osqp/nn/torch.py
@@ -1,12 +1,9 @@
 import numpy as np
 import scipy.sparse as spa
 
-try:
-    import torch
-    from torch.nn import Module
-    from torch.autograd import Function
-except ImportError as e:
-    print(f'Import Error: {e}')
+import torch
+from torch.nn import Module
+from torch.autograd import Function
 from joblib import Parallel, delayed
 import multiprocessing
 


### PR DESCRIPTION
I'm not sure why the following `print` statements were put in - merely `print`ing out an error and proceeding like nothing happened doesn't accomplish anything IMO, and only hides the otherwise invaluable stack trace. It's better to fail explicitly with an `ImportError`.

I noticed this when a bad installation of `torch` in my environment was preventing an internal import deep inside pytorch (triggered in our code on `from torch.nn import Module`), but this was hard to track down because of this `print`.

If the intention here was to allow `osqp` code execution even in the absence of the `torch` module, that's understandable, but again, no other code in `osqp` seems to be inadvertently picking up this module where it shouldn't except a unit test, and doing an `from osqp.nn.torch import ..` *should* trigger an `ImportError`.