### PR TITLE
Temporarily skip building wheels for 3.13 until it is released

### DIFF
--- a/.github/workflows/build_cuda.yml
+++ b/.github/workflows/build_cuda.yml
@@ -39,7 +39,8 @@ jobs:
         output-dir: wheelhouse
       env:
         CIBW_BUILD: "cp3*"
-        CIBW_SKIP: "cp36-* cp37-* *-win32 *-manylinux_i686 *-musllinux_* *-macosx_*"
+        # Temporarily skip 3.13 because it is still an RC and our dependencies aren't there yet
+        CIBW_SKIP: "cp36-* cp37-* *-win32 *-manylinux_i686 *-musllinux_* *-macosx_* cp313-*"
         CIBW_BUILD_VERBOSITY: 1
 
         # Clean the build directory between builds

--- a/.github/workflows/build_cuda.yml
+++ b/.github/workflows/build_cuda.yml
@@ -33,7 +33,7 @@ jobs:
         choco install windows-sdk-8.1
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.19
+      uses: pypa/cibuildwheel@v2.20
       with:
         package-dir: backend/cuda
         output-dir: wheelhouse

--- a/.github/workflows/build_default.yml
+++ b/.github/workflows/build_default.yml
@@ -63,7 +63,7 @@ jobs:
         platforms: arm64
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.19
+      uses: pypa/cibuildwheel@v2.20
       with:
         output-dir: wheelhouse
       env:

--- a/.github/workflows/build_default.yml
+++ b/.github/workflows/build_default.yml
@@ -68,7 +68,8 @@ jobs:
         output-dir: wheelhouse
       env:
         CIBW_BUILD: "cp3*"
-        CIBW_SKIP: "cp36-* cp37-* *-win32 *-manylinux_i686 *-musllinux_*"
+        # Temporarily skip 3.13 because it is still an RC and our dependencies aren't there yet
+        CIBW_SKIP: "cp36-* cp37-* *-win32 *-manylinux_i686 *-musllinux_* cp313-*"
         # Clean the build directory between builds
         CIBW_BEFORE_BUILD: >-
           rm -rf {package}/osqp_sources/build

--- a/.github/workflows/build_mkl.yml
+++ b/.github/workflows/build_mkl.yml
@@ -31,7 +31,8 @@ jobs:
         output-dir: wheelhouse
       env:
         CIBW_BUILD: "cp3*"
-        CIBW_SKIP: "cp36-* cp37-* *-win32 *-manylinux_i686 *-musllinux_*"
+        # Temporarily skip 3.13 because it is still an RC and our dependencies aren't there yet
+        CIBW_SKIP: "cp36-* cp37-* *-win32 *-manylinux_i686 *-musllinux_* cp313-*"
         CIBW_BUILD_VERBOSITY: 1
 
         # Clean the build directory between builds

--- a/.github/workflows/build_mkl.yml
+++ b/.github/workflows/build_mkl.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.19
+      uses: pypa/cibuildwheel@v2.20
       with:
         package-dir: backend/mkl
         output-dir: wheelhouse


### PR DESCRIPTION
3.13 is in RC still, and not all dependencies have wheels for it built yet.

This should fix the issues we see in https://github.com/osqp/osqp-python/pull/155, since cibuildwheel 2.20 added Python 3.13.