### PR TITLE
Vb/interface fixes

### DIFF
--- a/.github/workflows/build_default.yml
+++ b/.github/workflows/build_default.yml
@@ -104,8 +104,7 @@ jobs:
       - name: Upload wheels to pypi
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-          TWINE_REPOSITORY: testpypi
+          TWINE_PASSWORD: ${{ secrets.pypi_password }}
         run: |
           python -m pip install --upgrade twine
           twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ authors = [
 dependencies = [
     "jinja2",
     "numpy>=1.7",
-    "qdldl",
     "scipy>=0.13.2",
     "setuptools",
     "joblib",


### PR DESCRIPTION
As Bart pointed out, `osqp-python` doesn't really need `qdldl`, so I've removed it from the list of dependencies. `qdldl` was only used when we were developing the derivatives code way back, and I guess it never got taken out.