### PR TITLE
Introduced an osqp.SolverStatus enum

### DIFF
--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -20,6 +20,10 @@ if __name__ == '__main__':
     # Solve problem
     res = prob.solve()
 
+    # Check solver status
+    # For all values, see https://osqp.org/docs/interfaces/status_values.html
+    assert res.info.status_val == osqp.SolverStatus.OSQP_SOLVED
+
     print('Status:', res.info.status)
     print('Objective value:', res.info.obj_val)
     print('Optimal solution x:', res.x)

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -17,8 +17,11 @@ if __name__ == '__main__':
     # Setup workspace and change alpha parameter
     prob.setup(P, q, A, l, u, alpha=1.0)
 
+    # Settings can be changed using .update_settings()
+    prob.update_settings(polishing=1)
+
     # Solve problem
-    res = prob.solve()
+    res = prob.solve(raise_error=True)
 
     # Check solver status
     # For all values, see https://osqp.org/docs/interfaces/status_values.html

--- a/examples/exception_handling.py
+++ b/examples/exception_handling.py
@@ -1,0 +1,33 @@
+import osqp
+import numpy as np
+from scipy import sparse
+
+
+"""
+
+`osqp.OSQPException`s might be raised during `.setup()`, `.update_settings()`,
+or `.solve()`. This example demonstrates how to catch an `osqp.OSQPException`
+raised during `.setup()`, and how to compare it to a specific `osqp.SolverError`.
+
+Exceptions other than `osqp.OSQPException` might also be raised, but these
+are typically errors in using the wrapper, and are not raised by the underlying
+`osqp` library itself.
+
+"""
+
+if __name__ == '__main__':
+
+    P = sparse.triu([[2.0, 5.0], [5.0, 1.0]], format='csc')
+    q = np.array([3.0, 4.0])
+    A = sparse.csc_matrix([[-1.0, 0.0], [0.0, -1.0], [-1.0, 3.0], [2.0, 5.0], [3.0, 4]])
+    l = -np.inf * np.ones(A.shape[0])
+    u = np.array([0.0, 0.0, -15.0, 100.0, 80.0])
+
+    prob = osqp.OSQP()
+
+    try:
+        prob.setup(P, q, A, l, u)
+    except osqp.OSQPException as e:
+        # Our problem is non-convex, so we get a osqp.OSQPException
+        # during .setup()
+        assert e == osqp.SolverError.OSQP_NONCVX_ERROR

--- a/src/bindings.cpp.in
+++ b/src/bindings.cpp.in
@@ -151,8 +151,7 @@ PyOSQPSolver::PyOSQPSolver(
 
     OSQPInt status = osqp_setup(&this->_solver, &this->_P.getcsc(), (OSQPFloat *)this->_q.data(), &this->_A.getcsc(), (OSQPFloat *)this->_l.data(), (OSQPFloat *)this->_u.data(), m, n, settings);
     if (status) {
-        std::string message = "Setup Error (Error Code " + std::to_string(status) + ")";
-        throw py::value_error(message);
+        throw py::value_error(std::to_string(status));
     }
 }
 
@@ -199,7 +198,12 @@ OSQPInt PyOSQPSolver::solve() {
 }
 
 OSQPInt PyOSQPSolver::update_settings(const OSQPSettings& new_settings) {
-    return osqp_update_settings(this->_solver, &new_settings);
+    OSQPInt status = osqp_update_settings(this->_solver, &new_settings);
+    if (status) {
+        throw py::value_error(std::to_string(status));
+    } else {
+        return status;
+    }
 }
 
 OSQPInt PyOSQPSolver::update_rho(OSQPFloat rho_new) {
@@ -352,6 +356,20 @@ PYBIND11_MODULE(@OSQP_EXT_MODULE_NAME@, m) {
     .value("OSQP_SIGINT", OSQP_SIGINT)
     .value("OSQP_UNSOLVED", OSQP_UNSOLVED)
     .export_values();
+
+    // Solver Errors
+    py::enum_<osqp_error_type>(m, "osqp_error_type", py::module_local())
+    .value("OSQP_NO_ERROR", OSQP_NO_ERROR)
+    .value("OSQP_DATA_VALIDATION_ERROR", OSQP_DATA_VALIDATION_ERROR)
+    .value("OSQP_SETTINGS_VALIDATION_ERROR", OSQP_SETTINGS_VALIDATION_ERROR)
+    .value("OSQP_LINSYS_SOLVER_INIT_ERROR", OSQP_LINSYS_SOLVER_INIT_ERROR)
+    .value("OSQP_NONCVX_ERROR", OSQP_NONCVX_ERROR)
+    .value("OSQP_MEM_ALLOC_ERROR", OSQP_MEM_ALLOC_ERROR)
+    .value("OSQP_WORKSPACE_NOT_INIT_ERROR", OSQP_WORKSPACE_NOT_INIT_ERROR)
+    .value("OSQP_ALGEBRA_LOAD_ERROR", OSQP_ALGEBRA_LOAD_ERROR)
+    .value("OSQP_CODEGEN_DEFINES_ERROR", OSQP_CODEGEN_DEFINES_ERROR)
+    .value("OSQP_DATA_NOT_INITIALIZED", OSQP_DATA_NOT_INITIALIZED)
+    .value("OSQP_FUNC_NOT_IMPLEMENTED", OSQP_FUNC_NOT_IMPLEMENTED);
 
     // Preconditioner Type
     py::enum_<osqp_precond_type>(m, "osqp_precond_type", py::module_local())

--- a/src/osqp/__init__.py
+++ b/src/osqp/__init__.py
@@ -2,10 +2,12 @@
 #   and is not in version control.
 from osqp._version import version as __version__  # noqa: F401
 from osqp.interface import (  # noqa: F401
+    OSQPException,
     OSQP,
     constant,
     algebra_available,
     algebras_available,
     default_algebra,
     SolverStatus,
+    SolverError,
 )

--- a/src/osqp/__init__.py
+++ b/src/osqp/__init__.py
@@ -7,4 +7,5 @@ from osqp.interface import (  # noqa: F401
     algebra_available,
     algebras_available,
     default_algebra,
+    SolverStatus,
 )

--- a/src/osqp/interface.py
+++ b/src/osqp/interface.py
@@ -89,18 +89,18 @@ def constant(which, algebra='builtin'):
         raise RuntimeError(f'Unknown constant {which}')
 
 
-def construct_enum(binding_enum_name):
+def construct_enum(name, binding_enum_name):
     """
     Dynamically construct an IntEnum from available enum members.
     For all values, see https://osqp.org/docs/interfaces/status_values.html
     """
     m = default_algebra_module()
     binding_enum = getattr(m, binding_enum_name)
-    return IntEnum('SolverStatus', [(v.name, v.value) for v in binding_enum.__members__.values()])
+    return IntEnum(name, [(v.name, v.value) for v in binding_enum.__members__.values()])
 
 
-SolverStatus = construct_enum('osqp_status_type')
-SolverError = construct_enum('osqp_error_type')
+SolverStatus = construct_enum('SolverStatus', 'osqp_status_type')
+SolverError = construct_enum('SolverError', 'osqp_error_type')
 
 
 class OSQPException(Exception):

--- a/src/osqp/interface.py
+++ b/src/osqp/interface.py
@@ -131,10 +131,11 @@ class OSQP:
             return_value = fn(*args, **kwargs)
         except ValueError as e:
             if e.args:
+                error_code = None
                 try:
                     error_code = int(e.args[0])
                 except ValueError:
-                    error_code = None
+                    pass
             raise OSQPException(error_code)
         else:
             return return_value

--- a/src/osqp/nn/torch.py
+++ b/src/osqp/nn/torch.py
@@ -122,9 +122,7 @@ def _OSQP_Fn(
                 """
                 num_solvers = len(solvers)
                 if num_solvers not in (0, n_batch):
-                    raise RuntimeError(
-                        f'Invalid number of solvers: expected 0 or {n_batch},' f' but got {num_solvers}.'
-                    )
+                    raise RuntimeError(f'Invalid number of solvers: expected 0 or {n_batch}, but got {num_solvers}.')
                 return num_solvers == n_batch
 
             def _inner_solve(i, update_flag, q, l, u, P_val, P_idx, A_val, A_idx, solver_type, eps_abs, eps_rel):
@@ -157,8 +155,8 @@ def _OSQP_Fn(
                         eps_rel=eps_rel,
                     )
                 result = solver.solve()
-                status = result.info.status
-                if status != 'solved':
+                status = result.info.status_val
+                if status != osqp.SolverStatus.OSQP_SOLVED:
                     # TODO: We can replace this with something calmer and
                     # add some more options around potentially ignoring this.
                     raise RuntimeError(f'Unable to solve QP, status: {status}')

--- a/src/osqp/tests/derivative_test.py
+++ b/src/osqp/tests/derivative_test.py
@@ -60,7 +60,7 @@ class derivative_tests(unittest.TestCase):
             verbose=True,
         )
         results = m.solve()
-        if results.info.status != 'solved':
+        if results.info.status_val != osqp.SolverStatus.OSQP_SOLVED:
             raise ValueError('Problem not solved!')
         x = results.x
         y = results.y
@@ -90,7 +90,7 @@ class derivative_tests(unittest.TestCase):
             verbose=False,
         )
         results = m.solve()
-        if results.info.status != 'solved':
+        if results.info.status_val != osqp.SolverStatus.OSQP_SOLVED:
             raise ValueError('Problem not solved!')
         grads = m.forward_derivative(dP=dP, dq=dq, dA=dA, dl=dl, du=du)
         return grads
@@ -122,7 +122,7 @@ class derivative_tests(unittest.TestCase):
             verbose=False,
         )
         res = osqp_solver.solve()
-        if res.info.status != 'solved':
+        if res.info.status_val != osqp.SolverStatus.OSQP_SOLVED:
             raise ValueError('Problem not solved!')
         x1 = res.x
         y1 = res.y
@@ -140,7 +140,7 @@ class derivative_tests(unittest.TestCase):
             verbose=False,
         )
         res = osqp_solver.solve()
-        if res.info.status != 'solved':
+        if res.info.status_val != osqp.SolverStatus.OSQP_SOLVED:
             raise ValueError('Problem not solved!')
         x2 = res.x
         y2 = res.y
@@ -188,7 +188,7 @@ class derivative_tests(unittest.TestCase):
             verbose=False,
         )
         res = osqp_solver.solve()
-        if res.info.status != 'solved':
+        if res.info.status_val != osqp.SolverStatus.OSQP_SOLVED:
             raise ValueError('Problem not solved!')
         x1 = res.x
         y1 = res.y
@@ -206,7 +206,7 @@ class derivative_tests(unittest.TestCase):
             verbose=False,
         )
         res = osqp_solver.solve()
-        if res.info.status != 'solved':
+        if res.info.status_val != osqp.SolverStatus.OSQP_SOLVED:
             raise ValueError('Problem not solved!')
         x2 = res.x
         y2 = res.y
@@ -257,7 +257,7 @@ class derivative_tests(unittest.TestCase):
             verbose=False,
         )
         res = osqp_solver.solve()
-        if res.info.status != 'solved':
+        if res.info.status_val != osqp.SolverStatus.OSQP_SOLVED:
             raise ValueError('Problem not solved!')
         x1 = res.x
         y1 = res.y
@@ -275,7 +275,7 @@ class derivative_tests(unittest.TestCase):
             verbose=False,
         )
         res = osqp_solver.solve()
-        if res.info.status != 'solved':
+        if res.info.status_val != osqp.SolverStatus.OSQP_SOLVED:
             raise ValueError('Problem not solved!')
         x2 = res.x
         y2 = res.y
@@ -319,7 +319,7 @@ class derivative_tests(unittest.TestCase):
                 verbose=False,
             )
             res = m.solve()
-            if res.info.status != 'solved':
+            if res.info.status_val != osqp.SolverStatus.OSQP_SOLVED:
                 raise ValueError('Problem not solved!')
             x_hat = res.x
 
@@ -361,7 +361,7 @@ class derivative_tests(unittest.TestCase):
                 verbose=False,
             )
             res = m.solve()
-            if res.info.status != 'solved':
+            if res.info.status_val != osqp.SolverStatus.OSQP_SOLVED:
                 raise ValueError('Problem not solved!')
             x_hat = res.x
 
@@ -405,7 +405,7 @@ class derivative_tests(unittest.TestCase):
                 verbose=False,
             )
             res = m.solve()
-            if res.info.status != 'solved':
+            if res.info.status_val != osqp.SolverStatus.OSQP_SOLVED:
                 raise ValueError('Problem not solved!')
             x_hat = res.x
 
@@ -445,7 +445,7 @@ class derivative_tests(unittest.TestCase):
                 verbose=False,
             )
             res = m.solve()
-            if res.info.status != 'solved':
+            if res.info.status_val != osqp.SolverStatus.OSQP_SOLVED:
                 raise ValueError('Problem not solved!')
             x_hat = res.x
 
@@ -484,7 +484,7 @@ class derivative_tests(unittest.TestCase):
                 verbose=False,
             )
             res = m.solve()
-            if res.info.status != 'solved':
+            if res.info.status_val != osqp.SolverStatus.OSQP_SOLVED:
                 raise ValueError('Problem not solved!')
             x_hat = res.x
 
@@ -530,7 +530,7 @@ class derivative_tests(unittest.TestCase):
                 verbose=False,
             )
             res = m.solve()
-            if res.info.status != 'solved':
+            if res.info.status_val != osqp.SolverStatus.OSQP_SOLVED:
                 raise ValueError('Problem not solved!')
             x_hat = res.x
 
@@ -573,7 +573,7 @@ class derivative_tests(unittest.TestCase):
                 verbose=False,
             )
             res = m.solve()
-            if res.info.status != 'solved':
+            if res.info.status_val != osqp.SolverStatus.OSQP_SOLVED:
                 raise ValueError('Problem not solved!')
             x_hat = res.x
 
@@ -615,7 +615,7 @@ class derivative_tests(unittest.TestCase):
                 verbose=False,
             )
             res = m.solve()
-            if res.info.status != 'solved':
+            if res.info.status_val != osqp.SolverStatus.OSQP_SOLVED:
                 raise ValueError('Problem not solved!')
             x_hat = res.x
 
@@ -658,7 +658,7 @@ class derivative_tests(unittest.TestCase):
                 verbose=False,
             )
             res = m.solve()
-            if res.info.status != 'solved':
+            if res.info.status_val != osqp.SolverStatus.OSQP_SOLVED:
                 raise ValueError('Problem not solved!')
             x_hat = res.x
             y_hat = res.y

--- a/src/osqp/tests/non_convex_test.py
+++ b/src/osqp/tests/non_convex_test.py
@@ -21,7 +21,7 @@ def self(algebra, solver_type, atol, rtol, decimal_tol):
 
 def test_non_convex_small_sigma(self, solver_type):
     if solver_type == 'direct':
-        with pytest.raises(ValueError):
+        with pytest.raises(osqp.OSQPException):
             self.model.setup(
                 P=self.P,
                 q=self.q,


### PR DESCRIPTION
I'm calling the enum `SolverStatus` since I understand there are other status values possible (during setup etc), but we can use `Status` if you think it won't be an issue in the future.

A typical usage would be:
```
res = prob.solve()
assert res.info.status_val == osqp.SolverStatus.OSQP_SOLVED
```

I'm still letting access to these status values to go through result -> info instead of through the solver directly, to maintain the "thin" in the thin python wrapper.